### PR TITLE
Fix/ruby23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get -qq install gdb
+  - gem install bundler
 
 script:
   - sudo sysctl kernel.yama.ptrace_scope=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get -qq install gdb
 
-script: bundle exec rspec spec
+script:
+  - sudo sysctl kernel.yama.ptrace_scope=0
+  - bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 
 rvm:
   - "2.0.0"
+  - "2.1.3"
+  - "2.2.5"
+  - "2.3.1"
 
 before_install:
   - sudo apt-get -qq update

--- a/bin/gdbruby.rb
+++ b/bin/gdbruby.rb
@@ -232,7 +232,7 @@ class RubyInternal
       when 1
         return @gdb.cmd_get_value("p #{line_info_table}[0].line_no").to_i
       else
-        (1..line_info_size).each do |i|
+        (1...line_info_size).each do |i|
           position = @gdb.cmd_get_value("p #{line_info_table}[#{i}].position").to_i
           if position == current_position
             return @gdb.cmd_get_value("p #{line_info_table}[#{i}].line_no").to_i
@@ -240,6 +240,7 @@ class RubyInternal
             return @gdb.cmd_get_value("p #{line_info_table}[#{i - 1}].line_no").to_i
           end
         end
+        return @gdb.cmd_get_value("p #{line_info_table}[#{line_info_size - 1}].line_no").to_i
       end
     end
     0

--- a/bin/gdbruby.rb
+++ b/bin/gdbruby.rb
@@ -379,6 +379,7 @@ class GDBRuby
   def show_environ
     i = 0
     puts "environ:"
+    @gdb.cmd_exec('info variables environ') # environ addr might be wrong. fix it.
     while true
       response = @gdb.cmd_get_value("p ((char **)environ)[#{i}]")
       break if response.empty? or response == '0x0'


### PR DESCRIPTION
@gunyarakun fix for ruby 2.3 or higher version. (maybe https://github.com/gunyarakun/gdbruby/issues/5 ?)

Related ruby changes:
* `iseq->xxx` -> `iseq->body->xxx` 
https://github.com/ruby/ruby/commit/e4198a73d406d9a9f61a6db2d2a243c0f5267679
* remvoe `rb_control_frame_t::me`. `me` is located at value stack.
https://github.com/ruby/ruby/commit/57b817f4c550e54ff57642b50723cc7c92bdd2fe

And `cmd_get_pointer` is changed for some type changes. Some types are now`const`.

Some simple tests (2.1.3, 2.2.5, 2.3.1):
https://gist.github.com/azrle/71ca5cf72ef8e8ccad0febbb03e34ee1